### PR TITLE
feat: add acceptance cookie banner

### DIFF
--- a/src/anchorfm-pupeteer/index.js
+++ b/src/anchorfm-pupeteer/index.js
@@ -60,6 +60,9 @@ async function postEpisode(youtubeVideoInfo) {
     logger.info('Setting language to English');
     await setLanguageToEnglish();
 
+    logger.info('Set cookie banner acceptance');
+    await setAcceptedCookieBannerDate();
+
     logger.info('Trying to log in and open episode wizard');
     await loginAndWaitForNewEpisodeWizard();
 
@@ -113,6 +116,17 @@ async function postEpisode(youtubeVideoInfo) {
   async function setLanguageToEnglish() {
     await clickSelector(page, 'button[aria-label="Change language"]');
     await clickSelector(page, '[data-testid="language-option-en"]');
+  }
+
+  async function setAcceptedCookieBannerDate() {
+    try {
+      await page.setCookie({
+        name: 'OptanonAlertBoxClosed',
+        value: new Date().toISOString(),
+      });
+    } catch (e) {
+      logger.info('-- Unable to set cookie');
+    }
   }
 
   async function loginAndWaitForNewEpisodeWizard() {


### PR DESCRIPTION
Add the cookie related to the cookie banner so we're going to remove any visibility issues to access the dom signin

```
Launching puppeteer
Setting language to English
Checking cookie banner
Trying to log in and open episode wizard
-- Accessing new Spotify login page for podcasts
-- Logging in
-- Trying to accepting spotify auth
-- Waiting for episode wizard to open
-- Episode wizard is opened
-- No need to accept spotify auth
Uploading audio file
-- Uploading audio file
-- Waiting for upload to finish
-- Audio file is uploaded
Filling required podcast details
-- Adding title
-- Adding description
-- No schedule, should publish immediately
-- Selecting content type(explicit or no explicit)
-- Selection content sponsorship (sponsored or not sponsored)
Filling optional podcast details
-- Clicking Additional Details
Skipping Interact step
-- Going to Interact step so we can skip it
-- Waiting before clicking next again to skip Interact step
-- Going to final step by skipping Interact step
Save draft or publish
-- Publishing
Yay
Finished successfully.
```