### PR TITLE
Fix uploading of episode, again, and fix the explicit content checkbox selection

### DIFF
--- a/src/anchorfm-pupeteer/index.js
+++ b/src/anchorfm-pupeteer/index.js
@@ -91,6 +91,7 @@ async function postEpisode(youtubeVideoInfo) {
 
     logger.info('Yay');
   } catch (err) {
+    logger.info(`Unable to post episode to spotify: ${err}`);
     if (page !== undefined) {
       logger.info('Screenshot base64:');
       const screenshotBinary = await page.screenshot({

--- a/src/anchorfm-pupeteer/index.js
+++ b/src/anchorfm-pupeteer/index.js
@@ -110,7 +110,7 @@ async function postEpisode(youtubeVideoInfo) {
   async function openNewPage(url) {
     const newPage = await browser.newPage();
     await newPage.goto(url);
-    await newPage.setViewport({ width: 1600, height: 1600 });
+    await newPage.setViewport({ width: 2560, height: 1440 });
     return newPage;
   }
 

--- a/src/anchorfm-pupeteer/index.js
+++ b/src/anchorfm-pupeteer/index.js
@@ -194,7 +194,8 @@ async function postEpisode(youtubeVideoInfo) {
   }
 
   async function uploadEpisode() {
-    logger.info('-- Uploading audio file');
+    logger.info('-- Uploading audio file(waiting 5 seconds before initiating process)');
+    await sleepSeconds(5);
     await page.waitForSelector('input[type=file]');
     const inputFile = await page.$('input[type=file]');
     await inputFile.uploadFile(env.AUDIO_FILE);

--- a/src/anchorfm-pupeteer/index.js
+++ b/src/anchorfm-pupeteer/index.js
@@ -110,7 +110,7 @@ async function postEpisode(youtubeVideoInfo) {
   async function openNewPage(url) {
     const newPage = await browser.newPage();
     await newPage.goto(url);
-    await newPage.setViewport({ width: 1600, height: 789 });
+    await newPage.setViewport({ width: 1600, height: 1600 });
     return newPage;
   }
 

--- a/src/anchorfm-pupeteer/index.js
+++ b/src/anchorfm-pupeteer/index.js
@@ -181,7 +181,7 @@ async function postEpisode(youtubeVideoInfo) {
   }
 
   function acceptSpotifyAuth() {
-    logger.info('-- Trying to accepting spotify auth');
+    logger.info('-- Trying to accept spotify auth');
     return clickSelector(page, 'button[data-testid="auth-accept"]').then(() => SPOTIFY_AUTH_ACCEPTED);
   }
 

--- a/src/anchorfm-pupeteer/index.js
+++ b/src/anchorfm-pupeteer/index.js
@@ -236,10 +236,11 @@ async function postEpisode(youtubeVideoInfo) {
     }
 
     logger.info('-- Selecting content type(explicit or no explicit)');
-    const selectorForExplicitContentLabel = env.IS_EXPLICIT
-      ? 'input[type="radio"][id="explicit-content"]'
-      : 'input[type="radio"][id="no-explicit-content"]';
-    await clickSelector(page, selectorForExplicitContentLabel, { visible: true });
+    if (env.IS_EXPLICIT) {
+      const explicitContentCheckboxLabelSelector =
+        '::-p-xpath(//span[contains(text(), "Explicit content")]/parent::*/parent::*//label)';
+      await clickSelector(page, explicitContentCheckboxLabelSelector);
+    }
 
     logger.info('-- Selection content sponsorship (sponsored or not sponsored)');
     const selectorForSponsoredContent = env.IS_SPONSORED

--- a/src/index.js
+++ b/src/index.js
@@ -47,30 +47,27 @@ async function main() {
 
 configureLogger();
 
-main()
-  .then(() => logger.info('Finished successfully.'))
-  .catch((err) => {
-    logger.info(`Posting youtube episode to spotify failed: ${err}`);
-    exitFailure();
-  })
-  .finally(() => {
-    exitSuccess();
-  });
+try {
+  await main();
+  logger.info('Finished successfully.')
+  await exitSuccess();
+} catch (err) {
+  logger.info(`Posting youtube episode to spotify failed: ${err}`);
+  await exitFailure();
+}
 
-function exitSuccess() {
-  try {
-    cleanUp();
-  } catch (err) {
-    /* empty */
-  }
+async function exitSuccess() {
+  await cleanUp();
   exit(0);
 }
 
-function exitFailure() {
-  cleanUp();
+async function exitFailure() {
+  await cleanUp();
   exit(1);
 }
 
 function cleanUp() {
-  shutdownLogger();
+  return new Promise((resolve) => {
+    shutdownLogger(() => resolve());
+  });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,8 @@ configureLogger();
 
 main()
   .then(() => logger.info('Finished successfully.'))
-  .catch(() => {
+  .catch((err) => {
+    logger.info(`Posting youtube episode to spotify failed: ${err}`);
     exitFailure();
   })
   .finally(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -47,14 +47,15 @@ async function main() {
 
 configureLogger();
 
-try {
-  await main();
-  logger.info('Finished successfully.')
-  await exitSuccess();
-} catch (err) {
-  logger.info(`Posting youtube episode to spotify failed: ${err}`);
-  await exitFailure();
-}
+main()
+  .then(async () => {
+    logger.info('Finished successfully.');
+    await exitSuccess();
+  })
+  .catch(async (err) => {
+    logger.info(`Posting youtube episode to spotify failed: ${err}`);
+    await exitFailure();
+  });
 
 async function exitSuccess() {
   await cleanUp();

--- a/src/index.js
+++ b/src/index.js
@@ -49,8 +49,7 @@ configureLogger();
 
 main()
   .then(() => logger.info('Finished successfully.'))
-  .catch((err) => {
-    logger.info(err);
+  .catch(() => {
     exitFailure();
   })
   .finally(() => {


### PR DESCRIPTION
Sometimes, the uploading won't even start at all, so I made it to wait 5 seconds(this number is chosen arbitrarily) before initiating episode upload. I am all ears if you have better ideas.

Additionally, the explicit content checkbox selection is fixed so now it works. Podcasters for spotify recently changed this so we needed to change it anyway.

Also the, viewport height is enlarged to get better screenshot.

Finaly, the logging when error occurs is improved: the error is logged before the base64 of screenshot  and it is logged in the puppeteer js file, not in the main js file.
